### PR TITLE
chore(gh-workflows): Bump runners to `ubuntu-24.04` from `ubuntu-20.04`

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Run ESLint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -25,7 +25,7 @@ jobs:
 
   prettier:
     name: Run Prettier
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
 
   tests:
     name: Run Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,17 +20,17 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          VERSION=$(basename ${GITHUB_REF#refs/tags/})
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION="$(basename "${GITHUB_REF#refs/tags/}")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Construct image metadata
         id: metadata
         env:
           REGISTRY: 'ghcr.io'
         run: |
-          REPO='${{ github.repository }}'
-          REGISTRY='${{ env.REGISTRY }}'
+          REPO="${{ github.repository }}"
+          REGISTRY="${{ env.REGISTRY }}"
           IMAGE_TAG_BASE="$REGISTRY/$REPO"
-          VERSION='${{ steps.get_version.outputs.version }}'
+          VERSION="${{ steps.get_version.outputs.version }}"
 
           TAGS="$IMAGE_TAG_BASE:latest"
           TAGS="$TAGS,$IMAGE_TAG_BASE:$VERSION"
@@ -38,10 +38,13 @@ jobs:
           echo "Using tags: $TAGS"
           echo "Using registry: $REGISTRY"
           echo "Version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo "build_cache_image=$IMAGE_TAG_BASE:build-cache" >> $GITHUB_OUTPUT
-          echo "creation=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+          {
+            echo "version=${VERSION}"
+            echo "tags=${TAGS}"
+            echo "build_cache_image=${IMAGE_TAG_BASE}:build-cache"
+            echo "creation=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_OUTPUT"
       - name: Verify metadata output
         run: |
           if [[ -z "${{ steps.metadata.outputs.version }}" ]]; then

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   get_metadata:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/sub-build-and-push-image.yml
+++ b/.github/workflows/sub-build-and-push-image.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   build_and_push_image:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Logging input
         run: |

--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@12f7cb8c93ab327c99dec3a1d502c0f314978afd # v1.55.0


### PR DESCRIPTION
**Changes**:

- **chore(gh-workflows)**: Bump runners to `ubuntu-24.04` (LTS) from `ubuntu-20.04`
- **fix(release-image)**: SC2086 and SC2129 issues
