### PR TITLE
fix(env): Do not use dynamic access with `import.meta.env`

### DIFF
--- a/scripts/sitemap-builder.ts
+++ b/scripts/sitemap-builder.ts
@@ -1,7 +1,6 @@
 import { EmojiMetadataReader } from '../src/lib/emojis/EmojiMetadataReader';
 import { EmojiFamily } from '../src/lib/emojis/EmojiTypes';
 import { UrlManager } from '../src/lib/UrlManager';
-import { getEnvRequired } from '../src/lib/utils';
 import {
   EnumChangefreq,
   simpleSitemapAndIndex,
@@ -9,7 +8,12 @@ import {
 } from 'sitemap';
 import { join } from 'path';
 
-const DOMAIN_NAME = getEnvRequired('VITE_DOMAIN_NAME');
+const DOMAIN_NAME = process.env.VITE_DOMAIN_NAME;
+
+if (!DOMAIN_NAME) {
+  throw new Error('The env var `VITE_DOMAIN_NAME` is required');
+}
+
 const BASE_URL = `https://${DOMAIN_NAME}`;
 
 (async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,13 +5,12 @@ import { GoogleAnalytics } from './components/GoogleAnalytics';
 import { EmojiFamilyProvider } from '@/providers/EmojiFamilyProvider';
 import { EmojiGridSettingsProvider } from '@/providers/EmojiGridSettingsProvider';
 import { PictureInPictureProvider } from '@/providers/PictureInPictureProvider';
-import { getEnvOptional } from '@/lib/utils';
 
 const CONTAINER = document.getElementById('root');
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const ROOT = createRoot(CONTAINER!);
 
-const G_TAG_ID = getEnvOptional('VITE_GA_TAG_ID');
+const G_TAG_ID = import.meta.env.VITE_GA_TAG_ID;
 
 ROOT.render(
   <React.StrictMode>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,17 +14,3 @@ export function toFixedNumber(
 
   return Math.round(num * pow) / pow;
 }
-
-export function getEnvOptional(envVar: string): string | undefined {
-  return (globalThis.process?.env ?? import.meta.env)[envVar];
-}
-
-export function getEnvRequired(envVar: string): string {
-  const value = getEnvOptional(envVar);
-
-  if (!value) {
-    throw new Error(`The \`${envVar}\` env var is not set`);
-  }
-
-  return value;
-}


### PR DESCRIPTION
**Changes**:
- **fix(env)**: Use import.meta.env.VITE_GA_TAG_ID explicitly
   - Vite's production build does not permit dynamic key access: https://v2.vitejs.dev/guide/env-and-mode.html#production-replacement