### PR TITLE
fix(AppGrid): Sticky top not applied for EmojiPanel if content height too small

### DIFF
--- a/src/components/AppGrid.tsx
+++ b/src/components/AppGrid.tsx
@@ -246,7 +246,7 @@ export const EmojiGrid = React.memo<EmojiGridProps>(
     );
 
     return (
-      <div className="flex flex-row gap-1 relative">
+      <div className="flex flex-row gap-1 relative min-h-[600px]">
         <div className="flex-1 grow">{grid}</div>
 
         {selectedEmoji !== null && (


### PR DESCRIPTION
**Changes**:

- **fix(AppGrid)**: Sticky top not applied for EmojiPanel if content height too small
    **Before**:
   ![image](https://github.com/user-attachments/assets/8bf94da9-3e7b-4c42-bbec-81206d35c5ea)
    **After**:
    ![image](https://github.com/user-attachments/assets/e0c56897-4e75-4cff-950e-29b88aca60da)


