### PR TITLE
fix(EmojiPanel): Copy to clipboard transient activation error on mobile

### DIFF
--- a/src/components/EmojiPanel.test.tsx
+++ b/src/components/EmojiPanel.test.tsx
@@ -135,6 +135,7 @@ describe('EmojiPanel', () => {
         write: vi.fn(),
       },
     });
+    global.ClipboardItem = vi.fn();
 
     // Act
     renderComponentWithProviders(
@@ -153,7 +154,7 @@ describe('EmojiPanel', () => {
     await userEvent.click(copyButton);
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    expect(navigator.clipboard.writeText).toHaveBeenCalledOnce();
+    expect(navigator.clipboard.write).toHaveBeenCalledOnce();
   });
 
   it('[component] should copy the emoji image to clipboard when copy button is clicked', async () => {

--- a/src/components/EmojiPanel.tsx
+++ b/src/components/EmojiPanel.tsx
@@ -20,23 +20,11 @@ import { useEmojiGridSettings } from '@/providers/EmojiGridSettingsProvider';
  * Copies the given text to the clipboard.
  * @param text - The text to be copied.
  */
-async function copyTextToClipboard(text: string): Promise<void> {
+function copyTextToClipboard(text: string): Promise<void> {
   return navigator.clipboard.writeText(text);
 }
 
-async function copyImageToClipboard(blob: Blob) {
-  if (!blob.type.startsWith('image/')) {
-    throw new Error('Provided blob is not an image.');
-  }
-
-  return navigator.clipboard.write([
-    new ClipboardItem({
-      [blob.type]: blob,
-    }),
-  ]);
-}
-
-function getFilenameFromPath(path: string) {
+function getFilenameFromPath(path: string): string {
   const normalizedPath = path.replace(/\\/g, '/');
 
   const filename = normalizedPath.substring(
@@ -111,17 +99,12 @@ function EmojiPanel({ emoji, id, onClose }: EmojiPanelProps): ReactNode {
   }, [emoji.id, settings.skintone]);
 
   const handleCopyClick = useCallback(async () => {
-    const res = await fetch(emojiStyle.url);
-    if (!res.ok) {
-      throw new Error('Failed to download SVG');
-    }
-    if (emojiStyle.isSvg) {
-      const svg = await res.text();
-      await copyTextToClipboard(svg);
-    } else {
-      const image = await res.blob();
-      await copyImageToClipboard(image);
-    }
+    const mimeType = emojiStyle.isSvg ? 'text/plain' : 'image/png';
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        [mimeType]: fetch(emojiStyle.url).then((res) => res.blob()),
+      }),
+    ]);
   }, [emojiStyle.id]);
 
   const handleDownloadClick = useCallback(() => {


### PR DESCRIPTION
**Changes**:

**fix(EmojiPanel)**: Copy to clipboard does not work on mobile

Mobile users were encountering the following error during clipboard copy on the `EmojiPanel` component. This error is caused by transient activation and this PR implements a workaround. 
  ```
  NotAllowedError: The request is not allowed by the user agent or 
  the platform in the current context, possibly because the user denied permission.
   ```
My understanding is we're seeing this because the internal timer for transient activation expired while waiting for the file download. By passing the `fetch` promise into `navigator.clipboard.write` instead of awaiting it and passing its blob, we avoid this. 

See this article for more details: https://webkit.org/blog/13862/the-user-activation-api/#:~:text=NotAllowedError%3A%20The%20request%20is%20not,%2C%20a%20).