### PR TITLE
feat(EmojiPanel): Use native share mechanism on mobile when sharing an emoji's URL

### DIFF
--- a/src/components/EmojiPanel.test.tsx
+++ b/src/components/EmojiPanel.test.tsx
@@ -268,6 +268,7 @@ describe('EmojiPanel', () => {
       clipboard: {
         writeText: vi.fn(),
       },
+      canShare: vi.fn(() => false),
     });
 
     const emoji = EMOJI_FIXTURES[0];
@@ -282,9 +283,7 @@ describe('EmojiPanel', () => {
     );
 
     // Assert
-    const copyUrlButton = screen.getByRole('button', {
-      name: /copy emoji url/i,
-    });
+    const copyUrlButton = screen.getByTestId('mobile-share-url');
     expect(copyUrlButton).toBeInTheDocument();
 
     await userEvent.click(copyUrlButton);


### PR DESCRIPTION
**Changes**:

- **feat(EmojiPanel)**: Use the native share mechanism on mobile when sharing an emoji's URL (`navigator.share`)
    
    For desktop users, the share button will still just copy the URL to the clipboard. I'm not fond of the native desktop share experience.